### PR TITLE
[CE][PR#2] 基线+阈值门控（relative+report）

### DIFF
--- a/docs/reference/cli/validate.md
+++ b/docs/reference/cli/validate.md
@@ -19,6 +19,7 @@ choreoatlas validate [options]
 | `--semantic` | bool | `true` | Enable semantic validation (CEL) |
 | `--causality` | string | `temporal` | Causality check mode: `strict`, `temporal`, or `off` |
 | `--baseline` | string | - | Path to baseline file for comparison |
+| `--baseline-missing` | string | `fail` | Strategy when baseline file is missing: `fail` or `treat-as-absolute` |
 | `--threshold-steps` | float | `0.9` | Step coverage threshold (0.0-1.0) |
 | `--threshold-conds` | float | `0.95` | Condition pass rate threshold (0.0-1.0) |
 | `--skip-as-fail` | bool | `false` | Treat SKIP conditions as FAIL |

--- a/docs/reports/ce-report.md
+++ b/docs/reports/ce-report.md
@@ -1,0 +1,91 @@
+# Baseline and Report Documentation
+
+## Overview
+
+The ChoreoAtlas CLI supports baseline comparison for tracking performance and validation quality over time. When a baseline is provided, the system switches from absolute threshold checking to relative comparison mode.
+
+## Baseline Comparison Modes
+
+### Absolute Mode (No Baseline)
+When no baseline is provided, thresholds are checked against absolute values:
+- Step coverage must meet the specified `--threshold-steps` (default 90%)
+- Condition pass rate must meet the specified `--threshold-conds` (default 95%)
+
+### Relative Mode (With Baseline)
+When a baseline is provided via `--baseline`, the system compares current metrics against the baseline:
+- Calculates delta percentages for both step coverage and condition pass rates
+- Thresholds now represent maximum allowed degradation
+- Example: `--threshold-steps 0.1` allows up to 10% degradation from baseline
+
+## Report Fields
+
+### Standard Fields
+- `stepsTotal`: Total number of steps in the flow
+- `stepsPass`: Number of steps that passed validation
+- `stepsCoverage`: Percentage of steps covered (0.0-1.0)
+- `conditionsTotal`: Total number of conditions evaluated
+- `conditionsPass`: Number of conditions that passed
+- `conditionsRate`: Pass rate for conditions (0.0-1.0)
+
+### Baseline Fields (when baseline is provided)
+- `baselineStepsCoverage`: Step coverage from baseline
+- `stepsDeltaAbs`: Absolute difference in step coverage
+- `stepsDeltaPct`: Percentage change from baseline
+- `baselineConditionsRate`: Condition pass rate from baseline
+- `conditionsDeltaAbs`: Absolute difference in condition rate
+- `conditionsDeltaPct`: Percentage change from baseline
+
+## Example Output
+
+### Without Baseline
+```
+[GATE] Baseline Gate: PASSED ✓
+  Steps Coverage: 95.0% (>= 90.0%)
+  Conditions Pass Rate: 98.0% (>= 95.0%)
+```
+
+### With Baseline
+```
+[GATE] Baseline Gate: PASSED ✓
+  Steps Coverage: 93.0% (>= 90.0%)
+  Conditions Pass Rate: 96.0% (>= 95.0%)
+  Baseline Comparison:
+    Steps: 95.0% baseline → 93.0% current (delta: -2.1%)
+    Conditions: 98.0% baseline → 96.0% current (delta: -2.0%)
+```
+
+## Baseline Missing Strategy
+
+The `--baseline-missing` flag controls behavior when the specified baseline file cannot be loaded:
+
+- `fail` (default): Exit with an error if the baseline file cannot be loaded
+- `treat-as-absolute`: Fall back to absolute threshold mode with a warning
+
+## Usage Examples
+
+### Record a Baseline
+```bash
+choreoatlas baseline record \
+  --flow order-flow.flowspec.yaml \
+  --trace traces/golden.json \
+  --out baseline.json
+```
+
+### Validate with Baseline Comparison
+```bash
+choreoatlas validate \
+  --flow order-flow.flowspec.yaml \
+  --trace traces/current.json \
+  --baseline baseline.json \
+  --threshold-steps 0.05 \
+  --threshold-conds 0.03
+```
+
+### Handle Missing Baseline
+```bash
+choreoatlas validate \
+  --flow order-flow.flowspec.yaml \
+  --trace traces/current.json \
+  --baseline baseline.json \
+  --baseline-missing treat-as-absolute
+```


### PR DESCRIPTION
### 背景
实现 #26 基线门控能力，支持相对模式比较和基线缺失策略。

### 改动
- ✅ 修复 baseline 传递问题（之前总是传 nil）
- ✅ 实现 relative 模式计算（delta 百分比）
- ✅ 报告新增 baseline_value/delta_abs/delta_pct 字段
- ✅ 新增 --baseline-missing 策略（fail|treat-as-absolute）
- ✅ 更新文档和示例

### 技术细节
**相对模式**：当提供基线时，阈值表示允许的最大降级幅度
- 步骤覆盖率：计算 (current - baseline) / baseline
- 条件通过率：同样计算相对变化
- 输出显示：baseline → current (delta: +/-X.X%)

**绝对模式**：无基线时使用固定阈值

### 兼容性
- 行为变化：有基线时启用相对门控
- 新增 CLI 参数：--baseline-missing

### 测试验证
- [x] 基础验证功能正常
- [x] 基线创建和记录
- [x] 基线比较（100% → 100%）
- [x] 部分覆盖降级（100% → 66.7%）
- [x] baseline-missing=fail 策略
- [x] baseline-missing=treat-as-absolute 策略

### 示例输出
```
[GATE] Baseline Gate: PASSED ✓
  Steps Coverage: 66.7% (>= 35.0%)
  Conditions Pass Rate: 100.0% (>= 95.0%)
  Baseline Comparison:
    Steps: 100.0% baseline → 66.7% current (delta: -33.3%)
    Conditions: 100.0% baseline → 100.0% current (delta: +0.0%)
```

Closes #26