### PR TITLE
PR#4: Schema Alignment - oneOf support for graph/flow formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ docker run --rm -v $(pwd):/workspace choreoatlas/cli:latest validate \
 
 ## 📋 Contract Structure
 
-### FlowSpec Format
+### FlowSpec Format (Graph - Recommended)
 ```yaml
 info:
   title: "Order Fulfillment Process"
@@ -89,19 +89,37 @@ services:
     spec: "./services/order-service.servicespec.yaml"
   inventoryService:
     spec: "./services/inventory-service.servicespec.yaml"
+graph:
+  nodes:
+    - id: "createOrder"
+      call: "orderService.createOrder"
+      output:
+        orderId: "response.orderId"
+    - id: "checkInventory"
+      call: "inventoryService.reserveInventory"
+      depends: ["createOrder"]
+      input:
+        orderId: "${orderId}"
+      output:
+        reservationId: "response.reservationId"
+```
+
+### FlowSpec Format (Sequential - Legacy)
+```yaml
+info:
+  title: "Order Fulfillment Process"
+services:
+  orderService:
+    spec: "./services/order-service.servicespec.yaml"
 flow:
   - step: "Create Order"
     call: "orderService.createOrder"
-    input:
-      customerId: "${customerId}"
-      items: "${items}"
     output:
-      orderResponse: "response.body"
+      orderId: "response.orderId"
   - step: "Reserve Inventory"
     call: "inventoryService.reserveInventory"
     input:
-      orderId: "${orderResponse.orderId}"
-      items: "${items}"
+      orderId: "${orderId}"
 ```
 
 ### ServiceSpec Format

--- a/docs/flowspec/schema.md
+++ b/docs/flowspec/schema.md
@@ -1,0 +1,136 @@
+# FlowSpec Schema Reference
+
+## Overview
+
+The FlowSpec schema defines the structure for ChoreoAtlas flow specifications. It supports two formats:
+- **Graph format** (recommended): DAG-based flow with explicit dependencies
+- **Flow format** (legacy): Sequential step-based flow
+
+## Schema Location
+
+- **External Schema**: `schemas/flowspec.schema.json`
+- **Internal Schema**: `internal/schemas/flowspec.schema.json`
+- **Schema ID**: `https://github.com/choreoatlas2025/cli/schemas/flowspec.schema.json`
+
+## Format Selection
+
+The schema uses `oneOf` to enforce mutual exclusivity between graph and flow formats:
+- A FlowSpec file must have either `graph` or `flow`, but not both
+- Graph format is recommended for new projects
+- Flow format is maintained for backward compatibility
+
+## Graph Format (Recommended)
+
+### Structure
+```yaml
+info:
+  title: "Flow Title"
+  description: "Optional description"
+  version: "1.0.0"
+
+services:
+  serviceName:
+    spec: "./path/to/service.spec.yaml"
+
+graph:
+  nodes:
+    - id: "nodeId"
+      call: "serviceName.operationId"
+      depends: ["previousNodeId"]  # Optional: dependencies
+      input:                       # Optional: input mappings
+        param: "${variable}"
+      output:                      # Optional: output mappings
+        varName: "response.field"
+  edges: []  # Optional: explicit edges (auto-generated from depends)
+```
+
+### Key Features
+- **Nodes**: Each node represents a service operation call
+- **Dependencies**: Use `depends` array to specify node dependencies
+- **Edges**: Automatically generated from `depends` field
+- **Variables**: Flow between nodes via `output` and `input` mappings
+
+### Example
+```yaml
+info:
+  title: "Order Processing"
+  version: "1.0.0"
+
+services:
+  orderService:
+    spec: "../services/order-service.servicespec.yaml"
+  inventoryService:
+    spec: "../services/inventory-service.servicespec.yaml"
+
+graph:
+  nodes:
+    - id: "createOrder"
+      call: "orderService.createOrder"
+      output:
+        orderId: "response.orderId"
+
+    - id: "checkInventory"
+      call: "inventoryService.reserveInventory"
+      depends: ["createOrder"]
+      input:
+        orderId: "${orderId}"
+      output:
+        reservationId: "response.reservationId"
+```
+
+## Flow Format (Legacy)
+
+### Structure
+```yaml
+info:
+  title: "Flow Title"
+
+services:
+  serviceName:
+    spec: "./path/to/service.spec.yaml"
+
+flow:
+  - step: "Step Name"
+    call: "serviceName.operationId"
+    input:
+      param: "${variable}"
+    output:
+      varName: "response.field"
+```
+
+### Parallel Steps
+```yaml
+flow:
+  - step: "Parallel Group"
+    parallel:
+      - step: "Parallel Step 1"
+        call: "service.operation1"
+      - step: "Parallel Step 2"
+        call: "service.operation2"
+```
+
+## Validation
+
+The schema is validated at two levels:
+
+1. **Structure Validation**: JSON Schema validation of the YAML structure
+2. **Semantic Validation**: Business logic validation (service references, variable flow, etc.)
+
+## VSCode Integration
+
+See [VSCode Setup Guide](../schemas/vscode-setup.md) for auto-completion and validation support.
+
+## Migration Guide
+
+To migrate from flow to graph format:
+
+1. Convert sequential steps to nodes with unique IDs
+2. Add `depends` field to establish execution order
+3. Keep the same `input`/`output` mappings
+4. Test with `choreoatlas lint` to verify correctness
+
+## Related Documentation
+
+- [VSCode Setup](../schemas/vscode-setup.md)
+- [Graph Format Guide](./graph-format.md)
+- [Migration Guide](../migration/flow-to-graph.md)

--- a/docs/schemas/vscode-setup.md
+++ b/docs/schemas/vscode-setup.md
@@ -1,0 +1,121 @@
+# VSCode Schema Association Setup
+
+## Overview
+
+This guide explains how to configure VSCode to use the ChoreoAtlas FlowSpec schema for validation and auto-completion.
+
+## Setup Instructions
+
+### Method 1: Project-level Configuration (Recommended)
+
+Add the following to your project's `.vscode/settings.json`:
+
+```json
+{
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/choreoatlas2025/cli/main/schemas/flowspec.schema.json": [
+      "*.flowspec.yaml",
+      "*.flowspec.yml"
+    ]
+  }
+}
+```
+
+### Method 2: User-level Configuration
+
+Open VSCode Settings (Cmd/Ctrl + ,) and search for "yaml.schemas". Add the schema mapping in the settings.json:
+
+```json
+{
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/choreoatlas2025/cli/main/schemas/flowspec.schema.json": [
+      "*.flowspec.yaml",
+      "*.flowspec.yml"
+    ]
+  }
+}
+```
+
+### Method 3: In-file Schema Declaration
+
+Add the following comment at the top of your FlowSpec file:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/choreoatlas2025/cli/main/schemas/flowspec.schema.json
+info:
+  title: "My Flow"
+  # ... rest of your FlowSpec
+```
+
+## Required Extensions
+
+Install the YAML Language Support extension by Red Hat:
+
+```bash
+code --install-extension redhat.vscode-yaml
+```
+
+## Features Enabled
+
+Once configured, you'll get:
+
+- **Validation**: Real-time validation against the FlowSpec schema
+- **Auto-completion**: IntelliSense for FlowSpec properties
+- **Hover Documentation**: Descriptions for properties on hover
+- **Error Highlighting**: Visual indicators for schema violations
+- **Format Detection**: Automatic detection of graph vs flow format
+
+## Testing the Configuration
+
+1. Create a new file with `.flowspec.yaml` extension
+2. Start typing - you should see auto-completion suggestions
+3. Try an invalid property - you should see error highlighting
+
+Example test file:
+
+```yaml
+info:
+  title: "Test Flow"
+services:
+  myService:
+    spec: "./my-service.yaml"
+graph:
+  nodes:
+    - id: "start"
+      call: "myService.operation"
+      # Type 'depends' here and see auto-completion
+```
+
+## Troubleshooting
+
+### Schema not loading
+
+1. Check internet connection (for remote schema)
+2. Verify the YAML extension is installed and enabled
+3. Reload VSCode window (Cmd/Ctrl + Shift + P -> "Reload Window")
+
+### Auto-completion not working
+
+1. Ensure file has `.flowspec.yaml` or `.flowspec.yml` extension
+2. Check that yaml.schemas setting is properly configured
+3. Look for errors in Output panel (View -> Output -> YAML)
+
+### Using local schema
+
+If you prefer using a local schema file:
+
+```json
+{
+  "yaml.schemas": {
+    "./schemas/flowspec.schema.json": [
+      "*.flowspec.yaml"
+    ]
+  }
+}
+```
+
+## Related Documentation
+
+- [FlowSpec Schema Reference](../flowspec/schema.md)
+- [Graph Format Guide](../flowspec/graph-format.md)
+- [Migration from Flow to Graph](../migration/flow-to-graph.md)

--- a/examples/flows/order-graph.flowspec.yaml
+++ b/examples/flows/order-graph.flowspec.yaml
@@ -1,0 +1,41 @@
+info:
+  title: "E-commerce Order Fulfillment (Graph Format)"
+  description: "Order processing flow using DAG format"
+  version: "1.0.0"
+
+services:
+  orderService:
+    spec: "../services/order-service.servicespec.yaml"
+  inventoryService:
+    spec: "../services/inventory-service.servicespec.yaml"
+  shippingService:
+    spec: "../services/shipping-service.servicespec.yaml"
+
+graph:
+  nodes:
+    - id: "createOrder"
+      call: "orderService.createOrder"
+      output:
+        orderId: "response.orderId"
+        customerId: "response.customerId"
+
+    - id: "checkInventory"
+      call: "inventoryService.reserveInventory"
+      depends: ["createOrder"]
+      input:
+        orderId: "${orderId}"
+        customerId: "${customerId}"
+      output:
+        reservationId: "response.reservationId"
+        reservedItems: "response.reservedItems"
+
+    - id: "createShipment"
+      call: "shippingService.createShipment"
+      depends: ["checkInventory"]
+      input:
+        orderId: "${orderId}"
+        customerId: "${customerId}"
+        items: "${reservedItems}"
+      output:
+        shipmentId: "response.shipmentId"
+        trackingNumber: "response.trackingNumber"

--- a/internal/schemas/flowspec.schema.json
+++ b/internal/schemas/flowspec.schema.json
@@ -1,90 +1,244 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://example.com/flowspec.schema.json",
+  "$id": "https://github.com/choreoatlas2025/cli/schemas/flowspec.schema.json",
+  "title": "ChoreoAtlas FlowSpec",
+  "description": "Schema for ChoreoAtlas flow specification supporting both graph and sequential flow formats",
   "type": "object",
-  "additionalProperties": false,
+
   "required": ["info", "services"],
   "properties": {
+    "info": { "$ref": "#/$defs/info" },
+    "services": { "$ref": "#/$defs/services" },
+    "graph": { "$ref": "#/$defs/graph" },
+    "flow": { "$ref": "#/$defs/flow" }
+  },
+
+  "additionalProperties": false,
+
+  "oneOf": [
+    {
+      "required": ["graph"],
+      "not": { "required": ["flow"] },
+      "description": "Graph (DAG) format - recommended"
+    },
+    {
+      "required": ["flow"],
+      "not": { "required": ["graph"] },
+      "description": "Sequential flow format - legacy"
+    }
+  ],
+
+  "$defs": {
     "info": {
       "type": "object",
+      "description": "Metadata about the flow specification",
       "required": ["title"],
       "additionalProperties": false,
-      "properties": { 
-        "title": { "type": "string", "minLength": 1 } 
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Title of the flow specification"
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional description of the flow"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the flow specification"
+        }
       }
     },
+
     "services": {
       "type": "object",
+      "description": "Service definitions and their specifications",
       "minProperties": 1,
       "additionalProperties": {
         "type": "object",
         "required": ["spec"],
         "additionalProperties": false,
-        "properties": { 
-          "spec": { "type": "string", "minLength": 1 } 
-        }
-      }
-    },
-    "flow": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["step", "call"],
         "properties": {
-          "step": { "type": "string", "minLength": 1 },
-          "call": { "type": "string", "pattern": "^[a-zA-Z_][\\w-]*\\.[a-zA-Z_][\\w-]*$" },
-          "input": {},
-          "output": {
-            "type": "object",
-            "additionalProperties": { "type": "string" }
-          },
-          "meta": { "type": "object" }
+          "spec": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Path to the service specification file"
+          }
         }
       }
     },
+
     "graph": {
       "type": "object",
+      "description": "DAG-based flow definition",
+      "required": ["nodes"],
       "additionalProperties": false,
-      "required": ["nodes", "edges"],
       "properties": {
         "nodes": {
           "type": "array",
           "minItems": 1,
+          "description": "List of nodes in the DAG",
           "items": {
             "type": "object",
-            "additionalProperties": false,
             "required": ["id", "call"],
+            "additionalProperties": false,
             "properties": {
-              "id": { "type": "string", "minLength": 1 },
-              "call": { "type": "string", "pattern": "^[a-zA-Z_][\\w-]*\\.[a-zA-Z_][\\w-]*$" },
-              "input": {},
+              "id": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[a-zA-Z_][\\w-]*$",
+                "description": "Unique identifier for the node"
+              },
+              "call": {
+                "type": "string",
+                "pattern": "^[a-zA-Z_][\\w-]*\\.[a-zA-Z_][\\w-]*$",
+                "description": "Service operation to call (format: service.operation)"
+              },
+              "depends": {
+                "type": "array",
+                "description": "List of node IDs this node depends on",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "input": {
+                "type": "object",
+                "description": "Input mappings for the operation",
+                "additionalProperties": true
+              },
               "output": {
                 "type": "object",
-                "additionalProperties": { "type": "string" }
+                "description": "Output variable mappings",
+                "additionalProperties": {
+                  "type": "string"
+                }
               },
-              "meta": { "type": "object" }
+              "meta": {
+                "type": "object",
+                "description": "Additional metadata for the node",
+                "additionalProperties": true
+              }
             }
           }
         },
         "edges": {
           "type": "array",
+          "description": "Optional explicit edge definitions",
           "items": {
             "type": "object",
-            "additionalProperties": false,
             "required": ["from", "to"],
+            "additionalProperties": false,
             "properties": {
-              "from": { "type": "string", "minLength": 1 },
-              "to": { "type": "string", "minLength": 1 }
+              "from": {
+                "type": "string",
+                "description": "Source node ID"
+              },
+              "to": {
+                "type": "string",
+                "description": "Target node ID"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Optional condition for the edge"
+              }
             }
           }
         }
       }
+    },
+
+    "flow": {
+      "type": "array",
+      "description": "Sequential flow definition",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Regular step",
+            "additionalProperties": false,
+            "required": ["step", "call"],
+            "properties": {
+              "step": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Step name"
+              },
+              "call": {
+                "type": "string",
+                "pattern": "^[a-zA-Z_][\\w-]*\\.[a-zA-Z_][\\w-]*$",
+                "description": "Service operation to call"
+              },
+              "input": {
+                "type": "object",
+                "description": "Input mappings",
+                "additionalProperties": true
+              },
+              "output": {
+                "type": "object",
+                "description": "Output variable mappings",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "description": "Additional metadata",
+                "additionalProperties": true
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Parallel step group",
+            "additionalProperties": false,
+            "required": ["step", "parallel"],
+            "properties": {
+              "step": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Parallel group name"
+              },
+              "parallel": {
+                "type": "array",
+                "minItems": 2,
+                "description": "Steps to execute in parallel",
+                "items": {
+                  "type": "object",
+                  "required": ["step", "call"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "step": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "call": {
+                      "type": "string",
+                      "pattern": "^[a-zA-Z_][\\w-]*\\.[a-zA-Z_][\\w-]*$"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "output": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
     }
-  },
-  "oneOf": [
-    { "required": ["flow"], "not": { "required": ["graph"] } },
-    { "required": ["graph"], "not": { "required": ["flow"] } }
-  ]
+  }
 }

--- a/schemas/flowspec.schema.json
+++ b/schemas/flowspec.schema.json
@@ -1,47 +1,243 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://example.com/flowspec.schema.json",
+  "$id": "https://github.com/choreoatlas2025/cli/schemas/flowspec.schema.json",
+  "title": "ChoreoAtlas FlowSpec",
+  "description": "Schema for ChoreoAtlas flow specification supporting both graph and sequential flow formats",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["info", "services", "flow"],
+
+  "required": ["info", "services"],
   "properties": {
+    "info": { "$ref": "#/$defs/info" },
+    "services": { "$ref": "#/$defs/services" },
+    "graph": { "$ref": "#/$defs/graph" },
+    "flow": { "$ref": "#/$defs/flow" }
+  },
+
+  "additionalProperties": false,
+
+  "oneOf": [
+    {
+      "required": ["graph"],
+      "not": { "required": ["flow"] },
+      "description": "Graph (DAG) format - recommended"
+    },
+    {
+      "required": ["flow"],
+      "not": { "required": ["graph"] },
+      "description": "Sequential flow format - legacy"
+    }
+  ],
+
+  "$defs": {
     "info": {
       "type": "object",
+      "description": "Metadata about the flow specification",
       "required": ["title"],
       "additionalProperties": false,
-      "properties": { 
-        "title": { "type": "string", "minLength": 1 } 
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Title of the flow specification"
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional description of the flow"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the flow specification"
+        }
       }
     },
+
     "services": {
       "type": "object",
+      "description": "Service definitions and their specifications",
       "minProperties": 1,
       "additionalProperties": {
         "type": "object",
         "required": ["spec"],
         "additionalProperties": false,
-        "properties": { 
-          "spec": { "type": "string", "minLength": 1 } 
+        "properties": {
+          "spec": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Path to the service specification file"
+          }
         }
       }
     },
+
+    "graph": {
+      "type": "object",
+      "description": "DAG-based flow definition",
+      "required": ["nodes"],
+      "additionalProperties": false,
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "minItems": 1,
+          "description": "List of nodes in the DAG",
+          "items": {
+            "type": "object",
+            "required": ["id", "call"],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[a-zA-Z_][\\w-]*$",
+                "description": "Unique identifier for the node"
+              },
+              "call": {
+                "type": "string",
+                "pattern": "^[a-zA-Z_][\\w-]*\\.[a-zA-Z_][\\w-]*$",
+                "description": "Service operation to call (format: service.operation)"
+              },
+              "depends": {
+                "type": "array",
+                "description": "List of node IDs this node depends on",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "input": {
+                "type": "object",
+                "description": "Input mappings for the operation",
+                "additionalProperties": true
+              },
+              "output": {
+                "type": "object",
+                "description": "Output variable mappings",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "description": "Additional metadata for the node",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "edges": {
+          "type": "array",
+          "description": "Optional explicit edge definitions",
+          "items": {
+            "type": "object",
+            "required": ["from", "to"],
+            "additionalProperties": false,
+            "properties": {
+              "from": {
+                "type": "string",
+                "description": "Source node ID"
+              },
+              "to": {
+                "type": "string",
+                "description": "Target node ID"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Optional condition for the edge"
+              }
+            }
+          }
+        }
+      }
+    },
+
     "flow": {
       "type": "array",
+      "description": "Sequential flow definition",
       "minItems": 1,
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["step", "call"],
-        "properties": {
-          "step": { "type": "string", "minLength": 1 },
-          "call": { "type": "string", "pattern": "^[a-zA-Z_][\\w-]*\\.[a-zA-Z_][\\w-]*$" },
-          "input": {},
-          "output": {
+        "oneOf": [
+          {
             "type": "object",
-            "additionalProperties": { "type": "string" }
+            "description": "Regular step",
+            "additionalProperties": false,
+            "required": ["step", "call"],
+            "properties": {
+              "step": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Step name"
+              },
+              "call": {
+                "type": "string",
+                "pattern": "^[a-zA-Z_][\\w-]*\\.[a-zA-Z_][\\w-]*$",
+                "description": "Service operation to call"
+              },
+              "input": {
+                "type": "object",
+                "description": "Input mappings",
+                "additionalProperties": true
+              },
+              "output": {
+                "type": "object",
+                "description": "Output variable mappings",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "description": "Additional metadata",
+                "additionalProperties": true
+              }
+            }
           },
-          "meta": { "type": "object" }
-        }
+          {
+            "type": "object",
+            "description": "Parallel step group",
+            "additionalProperties": false,
+            "required": ["step", "parallel"],
+            "properties": {
+              "step": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Parallel group name"
+              },
+              "parallel": {
+                "type": "array",
+                "minItems": 2,
+                "description": "Steps to execute in parallel",
+                "items": {
+                  "type": "object",
+                  "required": ["step", "call"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "step": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "call": {
+                      "type": "string",
+                      "pattern": "^[a-zA-Z_][\\w-]*\\.[a-zA-Z_][\\w-]*$"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "output": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
## Summary
Implements schema alignment as per PR#4 requirements, adding oneOf support for mutually exclusive graph/flow formats with proper validation.

## Changes
### Schema Updates
- ✅ Unified internal (`internal/schemas/`) and external (`schemas/`) FlowSpec schemas
- ✅ Added oneOf constraint for graph/flow mutual exclusivity 
- ✅ Made `edges` optional in graph format (auto-generated from `depends` field)
- ✅ Updated schema $id to stable URL: `https://github.com/choreoatlas2025/cli/schemas/flowspec.schema.json`

### Parser Enhancements  
- ✅ Added `EnsureEdges()` method for consistent edge building from depends
- ✅ Fixed variable flow validation for graph format
- ✅ Added support for graph format with automatic edge generation

### User Experience
- ✅ Added warning for legacy flow format usage
- ✅ Changed all error messages from Chinese to English
- ✅ Created comprehensive schema documentation (`docs/flowspec/schema.md`)
- ✅ Added VSCode setup guide for schema integration

### Examples
- ✅ Added `examples/flows/order-graph.flowspec.yaml` demonstrating graph format

## Test Results
```bash
# Graph format validation
./bin/choreoatlas lint --flow examples/flows/order-graph.flowspec.yaml
✓ Schema validation passed
✓ DAG structure validated

# Legacy flow format  
./bin/choreoatlas lint --flow examples/flows/order-fulfillment.flowspec.yaml
✓ Shows legacy format warning
✓ Still validates correctly

# Embedded schema works independently
✓ Functions without external schema file
```

## Migration Notes
- Existing flow format files continue to work with a deprecation warning
- Graph format is now the recommended approach
- VSCode users can get auto-completion with the provided setup guide

🤖 Generated with [Claude Code](https://claude.ai/code)