### PR TITLE
CE: Implement discover fail-fast schema+lint gate (fixes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ choreoatlas discover \
   --trace examples/traces/successful-order.trace.json \
   --out discovered.flowspec.yaml \
   --out-services ./services
+# By default, discover enforces JSON Schema + lint gates and only writes on success.
+# To bypass (not recommended), add: --no-validate
 
 # CI gate mode (combines lint + validate with proper exit codes)
 choreoatlas ci-gate --flow examples/flows/order-fulfillment.flowspec.yaml --trace examples/traces/successful-order.trace.json
@@ -144,6 +146,7 @@ ca validate --flow .flowspec.yaml --trace trace.json \
 
 # Discover specs from a trace (FlowSpec + ServiceSpec files)
 ca discover --trace trace.json --out discovered.flowspec.yaml --out-services ./services
+# Gate is enabled by default; use --no-validate to bypass (not recommended)
 
 # Run lint + validate in one go (CI gate)
 ca ci-gate --flow .flowspec.yaml --trace trace.json

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -72,6 +72,8 @@ ca validate --flow examples/flows/order-fulfillment.flowspec.yaml \
 ca discover --trace examples/traces/successful-order.trace.json \
   --out discovered.flowspec.yaml \
   --out-services ./services
+  # discover 默认开启 JSON Schema + Lint 门禁；失败则不落盘
+  # 如需跳过（不推荐）：加 --no-validate
 
 # CI Gate（组合 lint + validate，并提供标准退出码）
 ca ci-gate --flow examples/flows/order-fulfillment.flowspec.yaml --trace examples/traces/successful-order.trace.json
@@ -216,6 +218,7 @@ choreoatlas discover
   --out string           FlowSpec 输出（默认 "discovered.flowspec.yaml"）
   --out-services string  ServiceSpec 输出目录（默认 "./services"）
   --title string         FlowSpec 标题
+  --no-validate          跳过 Schema+Lint 门禁（不推荐）
 
 choreoatlas ci-gate
   --flow string          FlowSpec 文件路径
@@ -385,4 +388,3 @@ Apache 2.0，详见 [LICENSE](LICENSE)。
 - Discussions：https://github.com/choreoatlas2025/cli/discussions
 
 —— ChoreoAtlas CLI：以契约即代码映射、校验并引导你的服务编排
-


### PR DESCRIPTION
实现 #38（CE：Schema 校验 + Fail‑Fast 门禁）

主要变更
- discover：默认启用 JSON Schema（FlowSpec/ServiceSpec）+ 静态 Lint 门禁；仅在通过时落盘
- 新增参数：`--no-validate`（不推荐，仅用于临时绕过校验）
- 内置嵌入式 Schema 校验（离线，无需网络）
- 测试：新增通过/失败用例覆盖（`internal/cli/discover_validate_test.go`）

代码位置
- internal/cli/discover.go：集成门禁逻辑、加入 `--no-validate`
- internal/cli/discover_validate.go：门禁实现（Schema 校验 + Lint）
- internal/cli/discover_validate_test.go：单测
- internal/cli/root.go：帮助文案更新
- README.md / README.zh-CN.md：文档更新（说明默认门禁与 --no-validate）

验证方式
- 失败示例：
  - `go run ./cmd/choreoatlas discover --trace <含 "GET /health" 名称的 trace> --out out.yaml --out-services ./services`
  - 期望：失败并提示 `call` 不符合 `service.operation` 格式；不生成 out.yaml
- 跳过门禁：
  - 追加 `--no-validate` 可生成（不推荐）
- 成功示例：
  - 使用 `examples/traces/successful-order.trace.json`，可通过门禁并生成文件

说明
- CE 范围内，完全离线；使用 `internal/schemas` 中的嵌入式 JSON Schema
- 后续工作（其它 Issue）：operationId 归一化、遥测→契约映射策略
