### PR TITLE
fix(cli): stop baseline recording when validation fails

### DIFF
--- a/internal/cli/baseline.go
+++ b/internal/cli/baseline.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/choreoatlas2025/cli/internal/baseline"
+	"github.com/choreoatlas2025/cli/internal/cli/exitcode"
 	"github.com/choreoatlas2025/cli/internal/spec"
 	"github.com/choreoatlas2025/cli/internal/trace"
 	"github.com/choreoatlas2025/cli/internal/validate"
@@ -53,7 +54,11 @@ func runBaselineRecord(args []string) {
 	}
 
 	// Perform validation to get results
-	results, _ := validate.ValidateAgainstTrace(flow, opIndex, tr)
+	results, ok := validate.ValidateAgainstTrace(flow, opIndex, tr)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "Validation failed; baseline not recorded.")
+		os.Exit(exitcode.ValidationFailed)
+	}
 
 	// Record baseline
 	baselineData, err := baseline.RecordBaseline(flow, results, *flowPath)

--- a/internal/cli/baseline_test.go
+++ b/internal/cli/baseline_test.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2025 ChoreoAtlas contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/choreoatlas2025/cli/internal/cli/exitcode"
+)
+
+func TestBaselineRecordStopsWhenValidationFails(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("failed to resolve repo root: %v", err)
+	}
+
+	flowPath := filepath.Join(repoRoot, "examples", "flows", "order-fulfillment.flowspec.yaml")
+	if _, err := os.Stat(flowPath); err != nil {
+		t.Fatalf("flow spec not found: %v", err)
+	}
+
+	tracePath := filepath.Join(repoRoot, "examples", "traces", "failed-inventory.trace.json")
+	if _, err := os.Stat(tracePath); err != nil {
+		t.Fatalf("trace file not found: %v", err)
+	}
+
+	tempDir := t.TempDir()
+	outPath := filepath.Join(tempDir, "baseline.json")
+
+	binPath := filepath.Join(tempDir, "choreoatlas.testbin")
+	build := exec.Command("go", "build", "-o", binPath, "./cmd/choreoatlas")
+	build.Dir = repoRoot
+	build.Env = os.Environ()
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build choreoatlas binary: %v\n%s", err, output)
+	}
+
+	cmd := exec.Command(binPath, "baseline", "record", "--flow", flowPath, "--trace", tracePath, "--out", outPath)
+	cmd.Dir = repoRoot
+
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected baseline record to fail validation, got success: %s", output)
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %T: %v\noutput: %s", err, err, output)
+	}
+
+	if code := exitErr.ExitCode(); code != exitcode.ValidationFailed {
+		t.Fatalf("unexpected exit code: got %d, want %d\noutput: %s", code, exitcode.ValidationFailed, output)
+	}
+
+	if _, statErr := os.Stat(outPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no baseline file to be written, got stat error: %v", statErr)
+	}
+}


### PR DESCRIPTION
## Summary
- abort `baseline record` when the validation step fails and exit with the validation failure code
- add regression coverage ensuring no baseline file is written after a failed validation

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68daa5ad948c83299a43c2183065414a