### PR TITLE
[CC-1] Enhance README: Add quickstart & visual demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,44 @@ Map. Verify. Steer your cross-service choreography — a developer-friendly, Swi
 
 This is the Community Edition (CE): zero telemetry, fully offline.
 
+---
+
+## ⚡ Get Started in 2 Steps
+
+**1. Install & Init:**
+```bash
+brew install choreoatlas2025/homebrew-choreoatlas/choreoatlas
+choreoatlas init
+```
+
+**2. Validate Your First Flow:**
+```bash
+choreoatlas validate --trace traces/successful-order.trace.json
+```
+
+### See It In Action
+
+![Quickstart Demo](https://raw.githubusercontent.com/choreoatlas2025/marketing_job/main/assets/demos/quickstart.gif)
+
+*30-second demo: Discover contracts from traces → Validate → Catch misalignment*
+
+### Real CI Validation
+
+| ❌ Before: Missing Payment Step | ✅ After: Complete Flow |
+|---|---|
+| ![CI Fail](https://raw.githubusercontent.com/choreoatlas2025/marketing_job/main/assets/screenshots/ci-gate-fail.png) | ![CI Pass](https://raw.githubusercontent.com/choreoatlas2025/marketing_job/main/assets/screenshots/ci-gate-pass.png) |
+
+*Automated FlowSpec-Trace alignment checks in your CI pipeline*
+
+### Learn More
+
+- 📖 **[Read the Whitepaper](https://choreoatlas.io/whitepaper)** - Deep dive into Contract-as-Code
+- 🌐 **[Visit choreoatlas.com](https://choreoatlas.com)** - Product overview & pricing
+- 📰 **[Subscribe to Newsletter](https://buttondown.com/choreoatlas)** - Updates & insights
+- 💬 **[GitHub Discussions](https://github.com/choreoatlas2025/cli/discussions)** - Ask questions & share feedback
+
+---
+
 ChoreoAtlas is a Contract‑as‑Code platform for interactive logic governance following the Discover → Specify → Guide loop. It supports dual contracts (FlowSpec + ServiceSpec) and provides:
 - Atlas Scout: discover specs from trace data
 - Atlas Proof: validate choreography against runtime behavior


### PR DESCRIPTION
## Summary

Enhances README top section (~40 lines) with visual quickstart flow to reduce time-to-value for new users.

## Changes

**Non-invasive additions only** (38 lines inserted after line 12):

1. **⚡ Get Started in 2 Steps**
   - Install + init command
   - First validation command

2. **See It In Action**
   - Animated quickstart GIF (30s demo)
   - Source: `marketing_job/assets/demos/quickstart.gif`

3. **Real CI Validation**
   - Before/After comparison table
   - CI failure vs success screenshots
   - Source: `marketing_job/assets/screenshots/ci-gate-{fail,pass}.png`

4. **Learn More CTAs**
   - Whitepaper: https://choreoatlas.io/whitepaper
   - Website: https://choreoatlas.com
   - Newsletter: https://buttondown.com/choreoatlas
   - Discussions: GitHub Discussions

## Reproduction

### View Changes
\`\`\`bash
git fetch origin
git diff origin/main...feat/cc-1-readme-top -- README.md
\`\`\`

### Verify Links
\`\`\`bash
# Check all assets are accessible
curl -I https://raw.githubusercontent.com/choreoatlas2025/marketing_job/main/assets/demos/quickstart.gif
curl -I https://raw.githubusercontent.com/choreoatlas2025/marketing_job/main/assets/screenshots/ci-gate-fail.png
curl -I https://raw.githubusercontent.com/choreoatlas2025/marketing_job/main/assets/screenshots/ci-gate-pass.png
\`\`\`

## Impact

- **User experience**: Visual first impression → immediate value proposition
- **Onboarding**: 2-step quickstart vs scrolling to installation section
- **Conversion**: Direct CTAs for deeper engagement

## Screenshots

### Before
Current README starts directly with badges and description.

### After
New top section with quickstart, demo GIF, and CI comparison.

## KPI Tracking

Will track via marketing_job metrics:
- GitHub traffic to README
- Click-through rate on CTA links
- Newsletter signups from README

## Reference

- Task: CC-1 from `marketing_job/claude_code_tasks.md`
- Demo assets: `choreoatlas2025/quickstart-demo#1`
- CI screenshots: `choreoatlas2025/cli#49`